### PR TITLE
Add support for Economic Class + Acres Operated (PT-185986613)

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -57,10 +57,10 @@ function App() {
     setStatusGraphic(<ProgressIndicator/>);
     const res = await createTableFromSelections(selectedOptions);
     if (res !== "success") {
-      setStatusMessage(strings.fetchSuccess);
+      setStatusMessage(strings.fetchError);
       setStatusGraphic(<Error/>);
     } else {
-      setStatusMessage(strings.fetchError);
+      setStatusMessage(strings.fetchSuccess);
       setStatusGraphic(<Checkmark/>);
     }
   };

--- a/src/constants/codapMetadata.ts
+++ b/src/constants/codapMetadata.ts
@@ -204,6 +204,34 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "attributeNameInCodapTable": "Very Large Farm ($1 million or more)",
     "unitInCodapTable": "# of Farms"
   },
+  "AREA OPERATED: (1.0 TO 9.9 ACRES)": {
+    "attributeNameInCodapTable": "Less than 10 Acres",
+    "unitInCodapTable": "# of Farms"
+  },
+  "AREA OPERATED: (10.0 TO 49.9 ACRES)": {
+    "attributeNameInCodapTable": "10 - 50 Acres",
+    "unitInCodapTable": "# of Farms"
+  },
+  "AREA OPERATED: (50.0 TO 100 ACRES)": {
+    "attributeNameInCodapTable": "50 - 100 Acres",
+    "unitInCodapTable": "# of Farms"
+  },
+  "AREA OPERATED: (100 TO 500 ACRES)": {
+    "attributeNameInCodapTable": "100 - 500 Acres",
+    "unitInCodapTable": "# of Farms"
+  },
+  "AREA OPERATED: (500 TO 999 ACRES)": {
+    "attributeNameInCodapTable": "500 - 1,000 Acres",
+    "unitInCodapTable": "# of Farms"
+  },
+  "AREA OPERATED: (1,000 TO 5,000 ACRES)": {
+    "attributeNameInCodapTable": "1,000 - 5,000 Acres",
+    "unitInCodapTable": "# of Farms"
+  },
+  "AREA OPERATED: (5,000 OR MORE ACRES)": {
+    "attributeNameInCodapTable": "5,000 Acres or More",
+    "unitInCodapTable": "# of Farms"
+  }
 };
 
 export const economicClassAttirbutes = [
@@ -213,4 +241,14 @@ export const economicClassAttirbutes = [
   "ECONOMIC CLASS: (250,000 TO 499,999 $)",
   "ECONOMIC CLASS: (500,000 TO 999,999 $)",
   "ECONOMIC CLASS: (1,000,000 OR MORE $)"
+];
+
+export const acresOperatedAttributes = [
+  "AREA OPERATED: (1.0 TO 9.9 ACRES)",
+  "AREA OPERATED: (10.0 TO 49.9 ACRES)",
+  "AREA OPERATED: (50.0 TO 100 ACRES)",
+  "AREA OPERATED: (100 TO 500 ACRES)",
+  "AREA OPERATED: (500 TO 999 ACRES)",
+  "AREA OPERATED: (1,000 TO 5,000 ACRES)",
+  "AREA OPERATED: (5,000 OR MORE ACRES)"
 ];

--- a/src/constants/codapMetadata.ts
+++ b/src/constants/codapMetadata.ts
@@ -179,5 +179,38 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
   "WHEAT - ACRES HARVESTED": {
     "attributeNameInCodapTable": "Wheat Area Harvested",
     "unitInCodapTable": "Acres Harvested"
-  }
+  },
+  "ECONOMIC CLASS: (1,000 TO 9,999 $)": {
+    "attributeNameInCodapTable": "Small Farm ($1,000 - $9,999)",
+    "unitInCodapTable": ""
+  },
+  "ECONOMIC CLASS: (10,000 TO 99,999 $)": {
+    "attributeNameInCodapTable": "Small Medium Farm ($10,000 - $99,000)",
+    "unitInCodapTable": "# of Farms"
+  },
+  "ECONOMIC CLASS: (100,000 TO 249,999 $)": {
+    "attributeNameInCodapTable": "Medium Farm ($100,000 - $249,000)",
+    "unitInCodapTable": "# of Farms"
+  },
+  "ECONOMIC CLASS: (250,000 TO 499,999 $)": {
+    "attributeNameInCodapTable": "Medium Large Farm ($250,000 - $499,999)",
+    "unitInCodapTable": "# of Farms"
+  },
+  "ECONOMIC CLASS: (500,000 TO 999,999 $)": {
+    "attributeNameInCodapTable": "Large Farm ($500,000 - $999,999)",
+    "unitInCodapTable": "# of Farms"
+  },
+  "ECONOMIC CLASS: (1,000,000 OR MORE $)": {
+    "attributeNameInCodapTable": "Very Large Farm ($1 million or more)",
+    "unitInCodapTable": "# of Farms"
+  },
 };
+
+export const economicClassAttirbutes = [
+  "ECONOMIC CLASS: (1,000 TO 9,999 $)",
+  "ECONOMIC CLASS: (10,000 TO 99,999 $)",
+  "ECONOMIC CLASS: (100,000 TO 249,999 $)",
+  "ECONOMIC CLASS: (250,000 TO 499,999 $)",
+  "ECONOMIC CLASS: (500,000 TO 999,999 $)",
+  "ECONOMIC CLASS: (1,000,000 OR MORE $)"
+];

--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -145,8 +145,8 @@ export const queryData: Array<IQueryHeaders> = [
       sect_desc: "Economics",
       group_desc: "Farms & Land & Assets",
       commodity_desc: "Farm Operations",
-      statisticcat_desc: "Area Operated",
-      short_desc: ["FARM OPERATIONS - ACRES OPERATED"],
+      statisticcat_desc: "Operations",
+      short_desc: ["FARM OPERATIONS - NUMBER OF OPERATIONS"],
       domain_desc: "Area Operated",
       geographicAreas: ["State", "County"],
       years: {

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -5,7 +5,7 @@ import { connect } from "./connect";
 import { cropOptions, fiftyStates } from "../constants/constants";
 import { countyData } from "../constants/counties";
 import { flatten, getQueryParams } from "./utils";
-import { attrToCODAPColumnName } from "../constants/codapMetadata";
+import { attrToCODAPColumnName, economicClassAttirbutes } from "../constants/codapMetadata";
 
 const baseURL = `https://quickstats.nass.usda.gov/api/api_GET/?key=9ED0BFB8-8DDD-3609-9940-A2341ED6A9E3`;
 
@@ -109,7 +109,12 @@ export const getAllAttrs = (selectedOptions: IStateOptions) => {
         throw new Error("Invalid attribute");
       }
       const {short_desc} = queryParams;
-      if (Array.isArray(short_desc)) {
+      if (attribute === "Economic Class") {
+        for (const econAttr of economicClassAttirbutes) {
+          const codapColumnName = attrToCODAPColumnName[econAttr].attributeNameInCodapTable;
+          allAttrs.push(codapColumnName);
+        }
+      } else if (Array.isArray(short_desc)) {
         for (const desc of short_desc) {
           const codapColumnName = attrToCODAPColumnName[desc].attributeNameInCodapTable;
           allAttrs.push(codapColumnName);
@@ -240,8 +245,13 @@ const getAttrData = async (params: IGetAttrDataParams) => {
   if (res) {
     const {data} = res;
     data.map((dataItem: any) => {
-       const codapColumnName = attrToCODAPColumnName[dataItem.short_desc].attributeNameInCodapTable;
-       return values[codapColumnName] = dataItem.Value;
+      let codapColumnName;
+      if (attribute === "Economic Class") {
+        codapColumnName = attrToCODAPColumnName[dataItem.domaincat_desc].attributeNameInCodapTable;
+      } else {
+       codapColumnName = attrToCODAPColumnName[dataItem.short_desc].attributeNameInCodapTable;
+      }
+      return values[codapColumnName] = dataItem.Value;
     });
   } else {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
This PR makes some changes to add support for the Economic Class and Acres Operated options. The requests and the responses for these options are a little different than the standard requests and responses, so they necessitated some custom work.