### PR TITLE
186581379 change table heirarchy

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -99,7 +99,6 @@ export const createRequest = ({attribute, geographicLevel, years, states, cropUn
 export const getAllAttrs = (selectedOptions: IStateOptions) => {
   const {geographicLevel, states, cropUnits, years, ...subOptions} = selectedOptions;
   const allAttrs: Array<string|ICropDataItem> = ["Year", geographicLevel, "Boundary"];
-  console.log("UNIT geographicLevel", geographicLevel);
 
   for (const key in subOptions) {
     const selections = subOptions[key as keyof typeof subOptions];
@@ -135,22 +134,18 @@ export const getAllAttrs = (selectedOptions: IStateOptions) => {
 
 export const createTableFromSelections = async (selectedOptions: IStateOptions, setReqCount: ISetReqCount) => {
   const {geographicLevel} = selectedOptions;
-  console.log("UNIT createTableFromSelections geographicLevel", geographicLevel);
 
   try {
     const allAttrs = getAllAttrs(selectedOptions);
     const items = await getItems(selectedOptions, setReqCount);
     await connect.getNewDataContext();
-    await connect.createStateCollection(geographicLevel === "State");
     if (geographicLevel === "County") {
-      // await connect.createStateCollection(true);
-      // await connect.createCountyCollection();
+      await connect.createStateCollection(true);
       await connect.createSubCollection(geographicLevel, allAttrs);
       await connect.createItems(items);
       await connect.makeCaseTableAppear();
       return "success";
     } else {
-    // await connect.createSubCollection(geographicLevel, allAttrs);
       await connect.createCollection(allAttrs);
       await connect.createItems(items);
       await connect.makeCaseTableAppear();

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -98,7 +98,8 @@ export const createRequest = ({attribute, geographicLevel, years, states, cropUn
 
 export const getAllAttrs = (selectedOptions: IStateOptions) => {
   const {geographicLevel, states, cropUnits, years, ...subOptions} = selectedOptions;
-  const allAttrs: Array<string|ICropDataItem> = ["Year"];
+  const allAttrs: Array<string|ICropDataItem> = ["Year", geographicLevel, "Boundary"];
+  console.log("UNIT geographicLevel", geographicLevel);
 
   for (const key in subOptions) {
     const selections = subOptions[key as keyof typeof subOptions];
@@ -134,18 +135,27 @@ export const getAllAttrs = (selectedOptions: IStateOptions) => {
 
 export const createTableFromSelections = async (selectedOptions: IStateOptions, setReqCount: ISetReqCount) => {
   const {geographicLevel} = selectedOptions;
+  console.log("UNIT createTableFromSelections geographicLevel", geographicLevel);
+
   try {
     const allAttrs = getAllAttrs(selectedOptions);
     const items = await getItems(selectedOptions, setReqCount);
     await connect.getNewDataContext();
     await connect.createStateCollection(geographicLevel === "State");
     if (geographicLevel === "County") {
-      await connect.createCountyCollection();
+      // await connect.createStateCollection(true);
+      // await connect.createCountyCollection();
+      await connect.createSubCollection(geographicLevel, allAttrs);
+      await connect.createItems(items);
+      await connect.makeCaseTableAppear();
+      return "success";
+    } else {
+    // await connect.createSubCollection(geographicLevel, allAttrs);
+      await connect.createCollection(allAttrs);
+      await connect.createItems(items);
+      await connect.makeCaseTableAppear();
+      return "success";
     }
-    await connect.createSubCollection(geographicLevel, allAttrs);
-    await connect.createItems(items);
-    await connect.makeCaseTableAppear();
-    return "success";
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log("Error creating CODAP Table from API data:", error);

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -152,7 +152,7 @@ export const createTableFromSelections = async (selectedOptions: IStateOptions, 
       await connect.makeCaseTableAppear();
       return "success";
     } else {
-      await connect.createCollection(allAttrs);
+      await connect.createCollection(allAttrs, geographicLevel);
       await connect.createItems(items);
       await connect.makeCaseTableAppear();
       return "success";

--- a/src/scripts/connect.js
+++ b/src/scripts/connect.js
@@ -11,30 +11,32 @@ export const connect = {
     },
 
     makeCODAPAttributeDef: function (attr, geoLevel) {
-      console.log("UNIT attr", attr, geoLevel);
       if (attr === "Boundary") {
         if (geoLevel === "County") {
           return (
             {
-              "name": attr,
-              "formula": `lookupBoundary(US_county_boundaries, County, State)`,
-              "formulaDependents": "State"
+              name: attr,
+              type: "boundary",
+              formula: `lookupBoundary(US_county_boundaries, County, State)`,
+              formulaDependents: "State"
             }
           )
-        }
-        if (geoLevel === "State") {
+        } else {
           return (
             {
-              "name": attr,
-              "formula": `lookupBoundary(US_state_boundaries, State)`,
-              "formulaDependents": "State"
+              name: attr,
+              type: "boundary",
+              formula: `lookupBoundary(US_state_boundaries, State)`,
+              formulaDependents: "State"
             }
           )
         }
       }
       return {
         name: attr,
-        type: "numeric"
+        type: attr === "Boundary" ? "boundary"
+                                  : attr === "State" || attr === "County"
+                                      ? " string" : "numeric"
       }
     },
 
@@ -117,13 +119,12 @@ export const connect = {
     },
 
     createSubCollection: async function(geoLevel, attrs) {
-      const plural = (geoLevel === "State") && "States";
       const message = {
         "action": "create",
         "resource": `dataContext[${dataSetName}].collection`,
         "values": {
           "name": "Data",
-          "parent": plural,
+          "parent": "States",
           "attributes": attrs.map((attr) => this.makeCODAPAttributeDef(attr, geoLevel))
         }
       };
@@ -136,6 +137,7 @@ export const connect = {
         "resource": `dataContext[${dataSetName}].collection`,
         "values": {
           "name": "Data",
+          "parent": "_root_",
           "attributes": attrs.map((attr) => this.makeCODAPAttributeDef(attr))
         }
       };

--- a/src/scripts/connect.js
+++ b/src/scripts/connect.js
@@ -11,11 +11,11 @@ export const connect = {
     },
 
     makeCODAPAttributeDef: function (attr, geoLevel) {
-      if (attr === "Boundary") {
+      if (attr.name === "Boundary") {
         if (geoLevel === "County") {
           return (
             {
-              name: attr,
+              name: attr.name,
               type: "boundary",
               formula: `lookupBoundary(US_county_boundaries, County, State)`,
               formulaDependents: "State"
@@ -24,7 +24,7 @@ export const connect = {
         } else {
           return (
             {
-              name: attr,
+              name: attr.name,
               type: "boundary",
               formula: `lookupBoundary(US_state_boundaries, State)`,
               formulaDependents: "State"
@@ -33,10 +33,10 @@ export const connect = {
         }
       }
       return {
-        name: attr,
-        type: attr === "Boundary" ? "boundary"
-                                  : attr === "State" || attr === "County"
-                                      ? " string" : "numeric"
+        name: attr.name,
+        type: attr.name === "Boundary" ? "boundary"
+                                  : attr.name === "State" || attr.name === "County"
+                                      ? "string" : "numeric"
       }
     },
 
@@ -131,14 +131,14 @@ export const connect = {
       await codapInterface.sendRequest(message);
     },
 
-    createCollection: async function(attrs) {
+    createCollection: async function(attrs, geoLevel) {
       const message = {
         "action": "create",
         "resource": `dataContext[${dataSetName}].collection`,
         "values": {
           "name": "Data",
           "parent": "_root_",
-          "attributes": attrs.map((attr) => this.makeCODAPAttributeDef(attr))
+          "attributes": attrs.map((attr) => this.makeCODAPAttributeDef(attr, geoLevel))
         }
       };
       await codapInterface.sendRequest(message);


### PR DESCRIPTION
Requet was to be able to add attribute legends to the map but whith current heirarchical set up, CODAP doesn't respond adding attributes to the map.
By flattening the table by one level, the boundary data is on the same level as the attributes allowing maps to have the attribute legends.