### PR TITLE
Adds back units that get missed on merging main to the table flattening

### DIFF
--- a/src/scripts/connect.js
+++ b/src/scripts/connect.js
@@ -34,6 +34,7 @@ export const connect = {
       }
       return {
         name: attr.name,
+        unit: attr.unit,
         type: attr.name === "Boundary" ? "boundary"
                                   : attr.name === "State" || attr.name === "County"
                                       ? "string" : "numeric"


### PR DESCRIPTION
Units got left out when I resolved merge conflict on the table flattening PR.