### PR TITLE
chore: add data from 2022 (NP-1)

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -74,6 +74,7 @@ context("Test the overall app", () => {
     it("expands and collapses Years section when clicked", () => {
       cy.get("[data-testid^='dropdown-Years-toggle']").click();
       cy.get("[data-testid^='dropdown-Years-body']").should("be.visible");
+      cy.get("[data-testid^='dropdown-Years-body']").should("contain.text", "Please select attributes to see available years.");
       cy.get("[data-testid^='dropdown-Years-toggle']").click();
       cy.get("[data-testid^='dropdown-Years-body']").should("not.be.visible");
     });

--- a/src/components/years-options.tsx
+++ b/src/components/years-options.tsx
@@ -27,7 +27,7 @@ export const YearsOptions: React.FC<IProps> = (props) => {
     }
 
     const allSelectedAttrs = flatten(selectedAttrKeys.map((key) => selectedOptions[key]));
-    const newAvailableYears = allSelectedAttrs.reduce((years, attr) => {
+    const newAvailableYears: string[] = allSelectedAttrs.reduce((years, attr) => {
       const subAttrData = queryData.find((d) => d.plugInAttribute === attr);
       const availableYears = subAttrData?.years[selectedOptions.geographicLevel];
       if (availableYears) {
@@ -36,8 +36,8 @@ export const YearsOptions: React.FC<IProps> = (props) => {
         });
       }
       return years;
-    }, new Set());
-    const newSet: string[] = Array.from(newAvailableYears);
+    }, new Set<string>());
+    const newSet: string[] = Array.from(newAvailableYears).sort((a, b) => parseInt(b, 10) - parseInt(a, 10));
     setAvailableYearOptions(newSet);
 
     // if selected years includes years not in available options, remove them from selection

--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -39,8 +39,8 @@ export const queryData: Array<IQueryHeaders> = [
       ...sharedDemographicHeaders,
       short_desc: ["PRODUCERS, (ALL) - NUMBER OF PRODUCERS"],
       years: {
-        "County": ["2017", "2012", "2007", "2002"],
-        "State": ["2017", "2012", "2007", "2002"]
+        "County": ["2022", "2017", "2012", "2007", "2002"],
+        "State": ["2022", "2017", "2012", "2007", "2002"]
       }
   },
   {
@@ -56,8 +56,8 @@ export const queryData: Array<IQueryHeaders> = [
         "PRODUCERS, AGE GE 75 - NUMBER OF PRODUCERS"
       ],
       years: {
-        "County": ["2017"],
-        "State": ["2017"]
+        "County": ["2022", "2017"],
+        "State": ["2022", "2017"]
       }
 
   },
@@ -69,8 +69,8 @@ export const queryData: Array<IQueryHeaders> = [
         "PRODUCERS, (ALL), MALE - NUMBER OF PRODUCERS"
       ],
       years: {
-        "County": ["2017"],
-        "State": ["2017"]
+        "County": ["2022", "2017"],
+        "State": ["2022", "2017"]
       }
   },
   {
@@ -86,8 +86,8 @@ export const queryData: Array<IQueryHeaders> = [
         "PRODUCERS, WHITE - NUMBER OF PRODUCERS"
       ],
       years: {
-        "County": ["2017"],
-        "State": ["2017"]
+        "County": ["2022", "2017"],
+        "State": ["2022", "2017"]
       }
   },
   {
@@ -117,8 +117,8 @@ export const queryData: Array<IQueryHeaders> = [
       domain_desc: "Total",
       geographicAreas: ["State", "County"],
       years: {
-        "County": ["1997", "2002", "2007", "2012", "2017"],
-        "State": ["1997", "2002", "2007", "2012", "2017"]
+        "County": ["2022", "2017", "2012", "2007", "2002", "1997"],
+        "State": ["2022", "2017", "2012", "2007", "2002", "1997"]
       }
   },
   {
@@ -142,8 +142,8 @@ export const queryData: Array<IQueryHeaders> = [
       domain_desc: "Area Operated",
       geographicAreas: ["State", "County"],
       years: {
-        "County": ["1997", "2002", "2007", "2012", "2017"],
-        "State": ["1997", "2002", "2007", "2012", "2017"]
+        "County": ["2022", "2017", "2012", "2007", "2002", "1997"],
+        "State": ["2022", "2017", "2012", "2007", "2002", "1997"]
       }
   },
   {
@@ -153,8 +153,8 @@ export const queryData: Array<IQueryHeaders> = [
       domain_desc: "Organic Status",
       geographicAreas: ["State", "County"],
       years: {
-        "County": ["2008", "2011", "2012", "2014", "2015", "2016", "2017", "2019", "2021"],
-        "State": ["2008", "2011", "2012", "2014", "2015", "2016", "2017", "2019", "2021"]
+        "County": ["2022", "2021", "2019", "2017", "2016", "2015", "2014", "2012", "2011", "2008"],
+        "State": ["2022", "2021", "2019", "2017", "2016", "2015", "2014", "2012", "2011", "2008"]
       }
   },
   {
@@ -169,8 +169,8 @@ export const queryData: Array<IQueryHeaders> = [
       domain_desc: "Total",
       geographicAreas: ["State", "County"],
       years: {
-        "County": ["2012", "2017"],
-        "State": ["2012", "2017"]
+        "County": ["2022", "2017", "2012"],
+        "State": ["2022", "2017", "2012"]
       }
   },
   {


### PR DESCRIPTION
[NP-1](https://concord-consortium.atlassian.net/browse/NP-1)

Adds the option to get data from 2022 for the following attributes:

- Total Farmers
- Age
- Gender
- Race
- Total Farms
- Organization Type (County)
- Acres Operated
- Organic
- Labor Status
- ~~Grapes - Acres Bearing (County)~~ This was already enabled.

Also adds some code that ensures year checkboxes are always listed from newest to oldest. Previously, in some configurations of selections, the years could appear in a seemingly random order (e.g. 2015, 2019, 2022, 2021, 2018...).

[NP-1]: https://concord-consortium.atlassian.net/browse/NP-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ