### PR TITLE
chore: add data from 2023 and 2024 (NP-2)

### DIFF
--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -1,7 +1,7 @@
 import { IQueryHeaders } from "./types";
 
 const allYears = [];
-for (let year = 2022; year >= 1910; year--) {
+for (let year = 2024; year >= 1910; year--) {
   allYears.push(`${year}`);
 }
 
@@ -228,8 +228,8 @@ export const queryData: Array<IQueryHeaders> = [
       ["Yield"]: ["COTTON - YIELD, MEASURED IN LB / ACRE"]
     },
     years: {
-      "County": allYears,
-      "State": allYears
+      "County": allYears.filter(y => Number(y) <= 2022),
+      "State": allYears.filter(y => Number(y) <= 2022)
     },
     ...sharedCropHeaders
   },
@@ -264,7 +264,7 @@ export const queryData: Array<IQueryHeaders> = [
       ["Yield"]: ["HAY - YIELD, MEASURED IN TONS / ACRE"]
     },
     years: {
-      "County": allYears,
+      "County": ["2022", "2017", "2012", ...allYears.filter(y => Number(y) <= 2008 && Number(y) >= 1918)],
       "State": allYears
     },
     ...sharedCropHeaders
@@ -318,7 +318,7 @@ export const queryData: Array<IQueryHeaders> = [
       ["Yield"]: ["TOBACCO - YIELD, MEASURED IN LB / ACRE"]
     },
     years: {
-      "County": allYears,
+      "County": ["2022", "2017", "2012", "2007", "2002", "1997"],
       "State": allYears
     },
     ...sharedCropHeaders
@@ -336,7 +336,7 @@ export const queryData: Array<IQueryHeaders> = [
       ["Yield"]: ["WHEAT - YIELD, MEASURED IN BU / ACRE"]
     },
     years: {
-      "County": allYears,
+      "County": allYears.filter(y => Number(y) <= 2022),
       "State": allYears
     },
     ...sharedCropHeaders


### PR DESCRIPTION
[NP-2](https://concord-consortium.atlassian.net/browse/NP-2)

Adds the option to get data from 2023 and 2024 for the following attributes:

- Total Farms
- Economic Class
- Wages
- Time Worked
- Corn - Yield, Acres Harvested
- Grapes - Yield
- Hay - Yield, Acres Harvested (State)
- Oats - Yield, Acres Harvested
- Soybeans - Yield, Acres Harvested
- Tobacco - Yield, Acres Harvested (State)
- Wheat - Yield, Acres Harvested (State)

Also adds new limitations on years for Hay and Tobacco county-level data.

[NP-2]: https://concord-consortium.atlassian.net/browse/NP-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ