### PR TITLE
chore: make compatible with CODAP v3 (NP-7)

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -173,14 +173,13 @@ const makeCODAPAttributeDef = (attr: Attribute, geoLevel: GeographicLevel) => {
     return {
       name,
       type: "boundary",
-      formula,
-      formulaDependents: "State"
+      formula
     };
   } else {
     return {
       name,
       unit,
-      type: name === "State" || name === "County" ? "string" : "numeric"
+      type: name === "State" || name === "County" ? "categorical" : "numeric"
     };
   }
 };


### PR DESCRIPTION
[NP-7](https://concord-consortium.atlassian.net/browse/NP-7)

Fixes CODAP v3 compatibility by replacing  non-standard "string" attribute type with "categorical", and removing obsolete `formulaDependents` property. Maintains compatibility with CODAP v2.

[NP-7]: https://concord-consortium.atlassian.net/browse/NP-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ