### PR TITLE
fix: cattle short_desc, livestock units in table (NP-8)

### DIFF
--- a/src/constants/codapMetadata.ts
+++ b/src/constants/codapMetadata.ts
@@ -248,25 +248,25 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "attributeNameInCodapTable": "5,000 Acres or More",
     "unitInCodapTable": "# of Farms"
   },
-  "CATTLE, CALVES - INVENTORY": {
+  "CATTLE, INCL CALVES - INVENTORY": {
     "attributeNameInCodapTable": "Cattle, Calves",
-    "unitInCodapTable": "Count"
+    "unitInCodapTable": "Head"
   },
   "CHICKENS, BROILERS - INVENTORY": {
     "attributeNameInCodapTable": "Chickens, Broilers",
-    "unitInCodapTable": "Count"
+    "unitInCodapTable": "Head"
   },
   "CHICKENS, LAYERS - INVENTORY": {
     "attributeNameInCodapTable": "Chickens, Layers",
-    "unitInCodapTable": "Count"
+    "unitInCodapTable": "Head"
   },
   "HOGS - INVENTORY": {
     "attributeNameInCodapTable": "Hogs",
-    "unitInCodapTable": "Count"
+    "unitInCodapTable": "Head"
   },
   "EQUINE, HORSES & PONIES - INVENTORY": {
     "attributeNameInCodapTable": "Horses & Ponies",
-    "unitInCodapTable": "Count"
+    "unitInCodapTable": "Head"
   }
 };
 

--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -369,7 +369,7 @@ export const queryData: Array<IQueryHeaders> = [
         ["Inventory"]: "Inventory"
       },
       short_desc: {
-        ["Inventory"]: ["CATTLE, CALVES - INVENTORY"]
+        ["Inventory"]: ["CATTLE, INCL CALVES - INVENTORY"]
       },
       years: {
         "County": yearsFrom(1920),

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -104,6 +104,17 @@ export const createRequest = ({attribute, geographicLevel, years, states, cropUn
     req = req + `&year=${year}`;
   });
 
+  states.forEach((state) => {
+    if (geographicLevel === "REGION : MULTI-STATE") {
+      if (state !== "Alaska") {
+        const region = multiRegions.find((r) => r.States.includes(state));
+        req = req + `&region_desc=${encodeURIComponent(region?.Region as string)}`;
+      }
+    } else {
+      req = req + `&state_name=${encodeURIComponent(state)}`;
+    }
+  });
+
   const itemArray = Array.isArray(item) ? item : (item ? [item] : []);
   itemArray.forEach(subItem => {
     req = req + `&short_desc=${encodeURIComponent(subItem)}`;


### PR DESCRIPTION
[NP-8](https://concord-consortium.atlassian.net/browse/NP-8)

Changes `short_desc` value for Cattle from "CATTLE, CALVES - INVENTORY" to "CATTLE, INCL CALVES - INVENTORY" since the latter is actually what we want, and re-instates code in `api.ts` accidentally deleted in [this earlier PR](https://github.com/concord-consortium/nass-codap-plugin/pull/38) that provides state names when requesting county-level data. Also changes livestock unit in CODAP table from "Count" to "Head".

[NP-8]: https://concord-consortium.atlassian.net/browse/NP-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ