### PR TITLE
feat: add Clear Data Selection button (NP-11)

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -13,6 +13,15 @@ context("Test the overall app", () => {
     cy.get(`[data-testid^='dropdown-${sectionName}-body'] label[for='${value}']`).should("contain.text", value);
   };
 
+  const makeMinimalSelection = () => {
+    cy.get("[data-testid^='dropdown-Attributes-toggle']").click();
+    cy.get("[data-testid^='dropdown-Attributes-body'] input[type='checkbox'][value='Corn']").check();
+    cy.get("[data-testid^='dropdown-Attributes-toggle']").click();
+    cy.get("[data-testid^='dropdown-Years-toggle']").click();
+    cy.get("[data-testid^='dropdown-Years-body'] input[type='checkbox'][value='2023']").check();
+    cy.get("[data-testid^='dropdown-Years-toggle']").click();
+  };
+
   describe("App loads properly", () => {
     it("renders with descriptive text", () => {
       cy.get(".app-sectionHeaderText").should("have.text", "Retrieve data on U.S. agricultural statistics at the state or county level.");
@@ -40,8 +49,9 @@ context("Test the overall app", () => {
       cy.get("[data-testid^='dropdown-Years-body']").should("not.be.visible");
     });
 
-    it("renders with a 'Get Data' button", () => {
-      cy.get("button").contains("Get Data");
+    it("renders with a 'Get Data' and a 'Clear Data Selection' buttons", () => {
+      cy.get("[data-testid='get-data-button']").should("be.visible").contains("Get Data");
+      cy.get("[data-testid='clear-data-selection-button']").should("be.visible").contains("Clear Data Selection");
     });
   });
 
@@ -112,6 +122,37 @@ context("Test the overall app", () => {
       cy.get("[data-testid^='dropdown-Years-body']").should("contain.text", "Please select attributes to see available years.");
       cy.get("[data-testid^='dropdown-Years-toggle']").click();
       cy.get("[data-testid^='dropdown-Years-body']").should("not.be.visible");
+    });
+  });
+
+  describe("Buttons functionality", () => {
+    it("initially renders both buttons as disabled before selections are made", () => {
+      cy.get("[data-testid='get-data-button']").should("be.disabled");
+      cy.get("[data-testid='clear-data-selection-button']").should("be.disabled");
+    });
+    
+    it("enables buttons when selections are made", () => {
+      makeMinimalSelection();
+      cy.get("[data-testid='get-data-button']").should("not.be.disabled");
+      cy.get("[data-testid='clear-data-selection-button']").should("not.be.disabled");
+    });
+
+    it("clears all selections and disables both buttons when 'Clear Data Selection' is clicked", () => {
+      cy.get("[data-testid^='dropdown-Place-toggle']").click();
+      cy.get("[data-testid^='dropdown-Place-body'] input[type='checkbox'][value='Texas']").check();
+      cy.get("[data-testid^='dropdown-Attributes-toggle']").click();
+      cy.get("[data-testid^='dropdown-Attributes-body'] input[type='checkbox'][value='Corn']").check();
+      cy.get("[data-testid^='dropdown-Attributes-body'] input[type='checkbox'][value='Cattle']").check();
+
+      cy.get("[data-testid^='dropdown-Place-body'] input[type='checkbox'][value='Texas']").should("be.checked");
+      cy.get("[data-testid^='dropdown-Attributes-body'] input[type='checkbox'][value='Corn']").should("be.checked");
+      cy.get("[data-testid^='dropdown-Attributes-body'] input[type='checkbox'][value='Cattle']").should("be.checked");
+
+      cy.get("[data-testid='clear-data-selection-button']").click();
+      cy.get("[data-testid^='dropdown-Place-body'] input[type='checkbox'][value='Texas']").should("not.be.checked");
+      cy.get("[data-testid^='dropdown-Attributes-body'] input[type='checkbox'][value='Corn']").should("not.be.checked");
+      cy.get("[data-testid^='dropdown-Attributes-body'] input[type='checkbox'][value='Cattle']").should("not.be.checked");
+      cy.get("[data-testid='clear-data-selection-button']").should("be.disabled");
     });
   });
 });

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -62,15 +62,20 @@ button:focus {
 }
 
 .summary {
+  align-items: baseline;
+  display: flex;
   flex-basis: 56px;
   flex-grow: 0;
   flex-shrink: 0;
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+  padding: 6px 0;
+
   .status {
-    display: flex;
     align-items: center;
+    display: flex;
+    flex: 1 1 100%;
     gap: 10px;
   }
 }
@@ -83,7 +88,6 @@ button:focus {
 }
 
 button {
-  margin: 6px;
   padding: 6px;
   border-radius: 3px;
   border: solid 1px $teal-light;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -189,10 +189,20 @@ function App() {
         })}
       </div>
       <div className={css.summary}>
-        <button className={css.clearButton} disabled={clearDataSelectionDisabled} onClick={handleClearDataSelection}>
+        <button
+          className={css.clearButton}
+          data-testid="clear-data-selection-button"
+          disabled={clearDataSelectionDisabled}
+          onClick={handleClearDataSelection}
+        >
           {strings.clearDataSelection}
         </button>
-        <button className={css.getDataButton} disabled={getDataDisabled} onClick={handleGetData}>
+        <button
+          className={css.getDataButton}
+          data-testid="get-data-button"
+          disabled={getDataDisabled}
+          onClick={handleGetData}
+        >
           {strings.getData}
         </button>
         <div className={css.status}>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -8,7 +8,7 @@ import { attributeOptions, categories, defaultSelectedOptions, fiftyStates } fro
 import { countyData } from "../constants/counties";
 import { IStateOptions } from "../constants/types";
 import { createTableFromSelections } from "../scripts/api";
-import { flatten } from "../scripts/utils";
+import { flatten, isDefaultSelection } from "../scripts/utils";
 import { queryData } from "../constants/queryHeaders";
 import { strings } from "../constants/strings";
 import ProgressIndicator from "../assets/progress-indicator.svg";
@@ -27,6 +27,7 @@ const iFrameDescriptor ={
 function App() {
   const [showInfo, setShowInfo] = useState<boolean>(false);
   const [selectedOptions, setSelectedOptions] = useState<IStateOptions>(defaultSelectedOptions);
+  const [clearDataSelectionDisabled, setClearDataSelectionDisabled] = useState<boolean>(true);
   const [getDataDisabled, setGetDataDisabled] = useState<boolean>(true);
   const [statusMessage, setStatusMessage] = useState<string>("");
   const [statusGraphic, setStatusGraphic] = useState<React.ReactElement>();
@@ -69,6 +70,11 @@ function App() {
     }
   }, [reqCount]);
 
+  useEffect(() => {
+    const isDefault = isDefaultSelection(selectedOptions, defaultSelectedOptions);
+    setClearDataSelectionDisabled(isDefault);
+  }, [selectedOptions]);
+
   const handleSetSelectedOptions = (newState: Partial<IStateOptions>) => {
     const newSelectedOptions = {...selectedOptions, ...newState};
     setSelectedOptions(newSelectedOptions);
@@ -102,6 +108,10 @@ function App() {
     } else {
       return states.length * years.length;
     }
+  };
+
+  const handleClearDataSelection = () => {
+    setSelectedOptions(defaultSelectedOptions);
   };
 
   const handleGetData = async () => {
@@ -179,13 +189,16 @@ function App() {
         })}
       </div>
       <div className={css.summary}>
+        <button className={css.clearButton} disabled={clearDataSelectionDisabled} onClick={handleClearDataSelection}>
+          {strings.clearDataSelection}
+        </button>
+        <button className={css.getDataButton} disabled={getDataDisabled} onClick={handleGetData}>
+          {strings.getData}
+        </button>
         <div className={css.status}>
           <div>{statusGraphic}</div>
           <div>{statusMessage}</div>
         </div>
-        <button className={css.getDataButton} disabled={getDataDisabled} onClick={handleGetData}>
-          {strings.getData}
-        </button>
       </div>
       { showWarning &&
         <Warning

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -5,6 +5,7 @@ interface IStrings {
 export const strings: IStrings = {
   appDescription: "Retrieve data on U.S. agricultural statistics at the state or county level.",
   infoTitle: "Further information about this CODAP plugin",
+  clearDataSelection: "Clear Data Selection",
   getData: "Get Data",
   yearsWarning: "Some of the attributes you selected are not available for all the years you selected.",
   rowsWarning: "The number of attributes you have selected is over 4000 rows and may lead to the program running slowly.",

--- a/src/scripts/utils.test.ts
+++ b/src/scripts/utils.test.ts
@@ -1,0 +1,172 @@
+import { flatten, getQueryParams, isDefaultSelection } from "./utils";
+import { IStateOptions } from "../constants/types";
+
+describe("utils", () => {
+  describe("flatten", () => {
+    it("should flatten a nested array", () => {
+      const input = [1, [2, 3], [4, [5, 6]]];
+      const expected = [1, 2, 3, 4, 5, 6];
+      expect(flatten(input)).toEqual(expected);
+    });
+
+    it("should handle an already flat array", () => {
+      const input = [1, 2, 3, 4];
+      const expected = [1, 2, 3, 4];
+      expect(flatten(input)).toEqual(expected);
+    });
+
+    it("should handle an empty array", () => {
+      const input: any[] = [];
+      const expected: any[] = [];
+      expect(flatten(input)).toEqual(expected);
+    });
+
+    it("should handle arrays with mixed types", () => {
+      const input = ["a", [1, "b"], [true, [null, "c"]]];
+      const expected = ["a", 1, "b", true, null, "c"];
+      expect(flatten(input)).toEqual(expected);
+    });
+
+    it("should handle deeply nested arrays", () => {
+      const input = [1, [2, [3, [4, [5]]]]];
+      const expected = [1, 2, 3, 4, 5];
+      expect(flatten(input)).toEqual(expected);
+    });
+  });
+
+  describe("getQueryParams", () => {
+    it("should return the correct query params for a valid attribute", () => {
+      const result = getQueryParams("Total Farmers");
+      expect(result).toBeDefined();
+      expect(result?.plugInAttribute).toBe("Total Farmers");
+    });
+
+    it("should return undefined for an invalid attribute", () => {
+      const result = getQueryParams("Nonexistent Attribute");
+      expect(result).toBeUndefined();
+    });
+
+    it("should return the correct query params for livestock attributes", () => {
+      const result = getQueryParams("Cattle");
+      expect(result).toBeDefined();
+      expect(result?.plugInAttribute).toBe("Cattle");
+      expect(result?.group_desc).toBe("Livestock");
+    });
+
+    it("should return the correct query params for crop attributes", () => {
+      const result = getQueryParams("Corn");
+      expect(result).toBeDefined();
+      expect(result?.plugInAttribute).toBe("Corn");
+      expect(result?.group_desc).toBe("Field Crops");
+    });
+  });
+
+  describe("isDefaultSelection", () => {
+    const defaultOptions: IStateOptions = {
+      geographicLevel: "State",
+      states: ["All States"],
+      farmerDemographics: [],
+      farmDemographics: [],
+      economicsAndWages: [],
+      cropUnits: [],
+      crops: [],
+      livestock: [],
+      years: []
+    };
+
+    it("should return true when selections match defaults exactly", () => {
+      const selectedOptions: IStateOptions = {
+        geographicLevel: "State",
+        states: ["All States"],
+        farmerDemographics: [],
+        farmDemographics: [],
+        economicsAndWages: [],
+        cropUnits: [],
+        crops: [],
+        livestock: [],
+        years: []
+      };
+
+      expect(isDefaultSelection(selectedOptions, defaultOptions)).toBe(true);
+    });
+
+    it("should return false when geographic level differs", () => {
+      const selectedOptions: IStateOptions = {
+        ...defaultOptions,
+        geographicLevel: "County"
+      };
+
+      expect(isDefaultSelection(selectedOptions, defaultOptions)).toBe(false);
+    });
+
+    it("should return false when states array differs", () => {
+      const selectedOptions: IStateOptions = {
+        ...defaultOptions,
+        states: ["California", "Texas"]
+      };
+
+      expect(isDefaultSelection(selectedOptions, defaultOptions)).toBe(false);
+    });
+
+    it("should return false when array has different length", () => {
+      const selectedOptions: IStateOptions = {
+        ...defaultOptions,
+        farmerDemographics: ["Total Farmers"]
+      };
+
+      expect(isDefaultSelection(selectedOptions, defaultOptions)).toBe(false);
+    });
+
+    it("should return false when array has same length but different content", () => {
+      const selectedOptions: IStateOptions = {
+        ...defaultOptions,
+        states: ["California"]
+      };
+
+      expect(isDefaultSelection(selectedOptions, defaultOptions)).toBe(false);
+    });
+
+    it("should return true when multiple arrays match exactly", () => {
+      const modifiedDefaults: IStateOptions = {
+        ...defaultOptions,
+        crops: ["Corn", "Wheat"],
+        livestock: ["Cattle"],
+        years: ["2023", "2022"]
+      };
+
+      const selectedOptions: IStateOptions = {
+        ...modifiedDefaults
+      };
+
+      expect(isDefaultSelection(selectedOptions, modifiedDefaults)).toBe(true);
+    });
+
+    it("should handle empty arrays correctly", () => {
+      const selectedOptions: IStateOptions = {
+        ...defaultOptions,
+        farmerDemographics: [],
+        farmDemographics: [],
+        economicsAndWages: []
+      };
+
+      expect(isDefaultSelection(selectedOptions, defaultOptions)).toBe(true);
+    });
+
+    it("should return false when only one property differs among many", () => {
+      const modifiedDefaults: IStateOptions = {
+        ...defaultOptions,
+        crops: ["Corn", "Wheat"],
+        livestock: ["Cattle"],
+        years: ["2023", "2022"],
+        farmerDemographics: ["Age", "Gender"]
+      };
+
+      const selectedOptions: IStateOptions = {
+        ...modifiedDefaults,
+        farmerDemographics: ["Age", "Gender", "Race"]
+      };
+
+      expect(isDefaultSelection(selectedOptions, modifiedDefaults)).toBe(false);
+    });
+  });
+});

--- a/src/scripts/utils.test.ts
+++ b/src/scripts/utils.test.ts
@@ -168,5 +168,49 @@ describe("utils", () => {
 
       expect(isDefaultSelection(selectedOptions, modifiedDefaults)).toBe(false);
     });
+
+    it("should return true when arrays have same elements in different order", () => {
+      const defaultsWithOrder: IStateOptions = {
+        ...defaultOptions,
+        crops: ["Corn", "Wheat", "Soybeans"],
+        years: ["2023", "2022", "2021"]
+      };
+
+      const selectedWithDifferentOrder: IStateOptions = {
+        ...defaultOptions,
+        crops: ["Wheat", "Soybeans", "Corn"],
+        years: ["2021", "2023", "2022"]
+      };
+
+      expect(isDefaultSelection(selectedWithDifferentOrder, defaultsWithOrder)).toBe(true);
+    });
+
+    it("should return false when arrays have different elements despite same length", () => {
+      const defaultsWithItems: IStateOptions = {
+        ...defaultOptions,
+        livestock: ["Cattle", "Chickens", "Horses & Ponies"]
+      };
+
+      const selectedWithDifferentItems: IStateOptions = {
+        ...defaultOptions,
+        livestock: ["Cattle", "Hogs", "Horses & Ponies"]
+      };
+
+      expect(isDefaultSelection(selectedWithDifferentItems, defaultsWithItems)).toBe(false);
+    });
+
+    it("should handle mixed types in arrays when comparing order-independently", () => {
+      const defaultsWithMixed: IStateOptions = {
+        ...defaultOptions,
+        states: ["California", "Texas", "New York"]
+      };
+
+      const selectedWithMixedOrder: IStateOptions = {
+        ...defaultOptions,
+        states: ["New York", "California", "Texas"]
+      };
+
+      expect(isDefaultSelection(selectedWithMixedOrder, defaultsWithMixed)).toBe(true);
+    });
   });
 });

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -16,8 +16,14 @@ export const isDefaultSelection = (selectedOptions: IStateOptions, defaultOption
     const defaultVal = defaultOptions[key as keyof IStateOptions];
 
     if (Array.isArray(selected) && Array.isArray(defaultVal)) {
-      return selected.length === defaultVal.length && 
-             selected.every((item, index) => item === defaultVal[index]);
+      if (selected.length !== defaultVal.length) {
+        return false;
+      }
+
+      // Sort both arrays to compare regardless of order
+      const sortedSelected = [...selected].sort();
+      const sortedDefault = [...defaultVal].sort();
+      return sortedSelected.every((item, index) => item === sortedDefault[index]);
     }
 
     return selected === defaultVal;

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -1,4 +1,5 @@
 import { queryData } from "../constants/queryHeaders";
+import { IStateOptions } from "../constants/types";
 
 export const flatten = (arr: any[]): any[] => {
   return arr.reduce((acc: any[], val: any) =>
@@ -7,4 +8,18 @@ export const flatten = (arr: any[]): any[] => {
 
 export const getQueryParams = (attribute: string) => {
   return queryData.find((d) => d.plugInAttribute === attribute);
+};
+
+export const isDefaultSelection = (selectedOptions: IStateOptions, defaultOptions: IStateOptions): boolean => {
+  return Object.keys(defaultOptions).every((key) => {
+    const selected = selectedOptions[key as keyof IStateOptions];
+    const defaultVal = defaultOptions[key as keyof IStateOptions];
+
+    if (Array.isArray(selected) && Array.isArray(defaultVal)) {
+      return selected.length === defaultVal.length && 
+             selected.every((item, index) => item === defaultVal[index]);
+    }
+
+    return selected === defaultVal;
+  });
 };


### PR DESCRIPTION
[NP-11](https://concord-consortium.atlassian.net/browse/NP-11)

Adds a "Clear Data Selection" button to the left of the "Get Data" button. When the selected options do not match the default options, the button is enabled. Clicking the button resets selected options to the defaults. The status message that used to appear to the left of the "Get Data" button now appears in its own row below the buttons because there was no longer enough room to display the status text and image on the same row. Also adds tests for all functions in `src/scripts/utils.ts`.

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-clear-data-selection-button](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-clear-data-selection-button/)

[NP-11]: https://concord-consortium.atlassian.net/browse/NP-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ