### PR TITLE
feat: Hierarchy in CODAP Table (NP-12)

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -240,9 +240,23 @@ const createStateCollection = async () => {
   await createParentCollection(dataSetName, "States", attrs);
 };
 
-const createSubCollection = async (geoLevel: GeographicLevel, attrs: Array<Attribute>) => {
-  const attrDefs = attrs.map((attr) => makeCODAPAttributeDef(attr, geoLevel));
-  await createChildCollection(dataSetName, "Data", "States", attrDefs);
+const createCountyCollection = async () => {
+  const attrs: Array<Attribute> = [
+    {"name": "County"},
+    makeCODAPAttributeDef({"name": "County Boundary"}, "County")
+  ];
+  await createChildCollection(dataSetName, "Counties", "States", attrs);
+};
+
+const createDataCollection = async (geoLevel: GeographicLevel, allAttrs: Array<Attribute>, parentCollection: string) => {
+  const dataAttrs = allAttrs.filter(attr => 
+    attr.name !== "State" && 
+    attr.name !== "State Boundary" && 
+    attr.name !== "County" && 
+    attr.name !== "County Boundary"
+  );
+  const dataAttrDefs = dataAttrs.map((attr) => makeCODAPAttributeDef(attr, geoLevel));
+  await createChildCollection(dataSetName, "Data", parentCollection, dataAttrDefs);
 };
 
 export const createTableFromSelections = async (selectedOptions: IStateOptions, setReqCount: ISetReqCount) => {
@@ -252,15 +266,19 @@ export const createTableFromSelections = async (selectedOptions: IStateOptions, 
     const allAttrs = getAllAttrs(selectedOptions);
     const items = await getItems(selectedOptions, setReqCount);
     await getNewDataContext();
+    
     if (geographicLevel === "County") {
+      // Three-level hierarchy: States > Counties > Data
       await createStateCollection();
-      await createSubCollection(geographicLevel, allAttrs);
+      await createCountyCollection();
+      await createDataCollection(geographicLevel, allAttrs, "Counties");
       await createItems(dataSetName, items);
       await createTable(dataSetName, dataSetName);
       return "success";
     } else {
-      const attrDefinitions = allAttrs.map((attr) => makeCODAPAttributeDef(attr, geographicLevel));
-      await createParentCollection(dataSetName, "Data", attrDefinitions);
+      // Two-level hierarchy: States > Data
+      await createStateCollection();
+      await createDataCollection(geographicLevel, allAttrs, "States");
       await createItems(dataSetName, items);
       await createTable(dataSetName, dataSetName);
       return "success";

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -234,15 +234,16 @@ const makeCODAPAttributeDef = (attr: Attribute, geoLevel: GeographicLevel) => {
 };
 
 const createStateCollection = async () => {
-  const attrs: Array<Attribute> = [{"name": "State"}];
-  const boundaryDef = makeCODAPAttributeDef({"name": "State Boundary"}, "State");
-  attrs.push(boundaryDef);
+  const attrs: Array<Attribute> = [
+    makeCODAPAttributeDef({"name": "State"}, "State"),
+    makeCODAPAttributeDef({"name": "State Boundary"}, "State")
+  ];
   await createParentCollection(dataSetName, "States", attrs);
 };
 
 const createCountyCollection = async () => {
   const attrs: Array<Attribute> = [
-    {"name": "County"},
+    makeCODAPAttributeDef({"name": "County"}, "County"),
     makeCODAPAttributeDef({"name": "County Boundary"}, "County")
   ];
   await createChildCollection(dataSetName, "Counties", "States", attrs);


### PR DESCRIPTION
[NP-12](https://concord-consortium.atlassian.net/browse/NP-12)

These changes ensure that state names and boundaries are placed in a parent collection, and the remaining data is placed in a child collection. If the "Size of area for data" option is set to "County", a third collection between the state and data collections is created to display the county names and boundaries. See screenshot below. (Note that county boundaries are currently not showing up in CODAP v3. That's a known bug being worked on separately.)

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/hierarchy-in-codap-table](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/hierarchy-in-codap-table/)

<img width="1500" height="884" alt="image" src="https://github.com/user-attachments/assets/9e7ebcdb-6a9d-48fa-99c9-4bb382a34af3" />


[NP-12]: https://concord-consortium.atlassian.net/browse/NP-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ