### PR TITLE
chore: Change data used for Cotton (NP-7)

### DIFF
--- a/src/constants/codapMetadata.ts
+++ b/src/constants/codapMetadata.ts
@@ -140,11 +140,11 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "attributeNameInCodapTable": "Corn Area Harvested",
     "unitInCodapTable": "Acres Harvested"
   },
-  "COTTON - YIELD, MEASURED IN LB / ACRE": {
+  "COTTON, UPLAND - YIELD, MEASURED IN LB / ACRE": {
     "attributeNameInCodapTable": "Cotton Yield",
     "unitInCodapTable": "LB/Acre"
   },
-  "COTTON - ACRES HARVESTED": {
+  "COTTON, UPLAND - ACRES HARVESTED": {
     "attributeNameInCodapTable": "Cotton Area Harvested",
     "unitInCodapTable": "Acres Harvested"
   },

--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -244,8 +244,8 @@ export const queryData: Array<IQueryHeaders> = [
       ["Yield"]: "Yield"
     },
     short_desc: {
-      ["Area Harvested"]: ["COTTON - ACRES HARVESTED"],
-      ["Yield"]: ["COTTON - YIELD, MEASURED IN LB / ACRE"]
+      ["Area Harvested"]: ["COTTON, UPLAND - ACRES HARVESTED"],
+      ["Yield"]: ["COTTON, UPLAND - YIELD, MEASURED IN LB / ACRE"]
     },
     years: {
       "County": yearsUpTo(2022),

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -124,6 +124,11 @@ export const createRequest = ({attribute, geographicLevel, years, states, cropUn
     req = req + `&freq_desc=ANNUAL`;
   }
 
+  // For crops, filter to get final annual values
+  if (cropOptions.options.includes(attribute)) {
+    req = req + `&reference_period_desc=YEAR`;
+  }
+
   return req;
 };
 


### PR DESCRIPTION
[NP-7](https://concord-consortium.atlassian.net/browse/NP-3)

Changes the Cotton attribute to use "Cotton, Upland - Yield" and "Cotton, Upland - Acres Harvested" instead of " Cotton - Yield" and "Cotton - Acres Harvested". Also adds `reference_period_desc=YEAR` to crop queries to ensure we use the final annual data instead of monthly forecast data.

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/change-data-for-cotton/](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/change-data-for-cotton/)

[NP-7]: https://concord-consortium.atlassian.net/browse/NP-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ