### PR TITLE
feat: add Production option to crop unit options (NP-10)

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -103,7 +103,7 @@ context("Test the overall app", () => {
         // Economics & Wages
         "Labor Status", "Wages", "Time Worked",
         // Crop Production - unit
-        "Area Harvested", "Yield",
+        "Area Harvested", "Production", "Yield",
         // Crop Production - crops
         "Corn", "Cotton", "Grapes", "Hay", "Oats", "Soybeans", "Tobacco", "Wheat",
         // Livestock

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -21,7 +21,7 @@ const iFrameDescriptor ={
   version: "0.0.1",
   pluginName: "nass-plugin",
   title: "NASS Quickstats Data",
-  dimensions: {width: 300, height: 400},
+  dimensions: {width: 327, height: 400},
 };
 
 function App() {

--- a/src/constants/codapMetadata.ts
+++ b/src/constants/codapMetadata.ts
@@ -140,6 +140,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "attributeNameInCodapTable": "Corn Area Harvested",
     "unitInCodapTable": "Acres Harvested"
   },
+  "CORN, GRAIN - PRODUCTION, MEASURED IN BU": {
+    "attributeNameInCodapTable": "Corn Production",
+    "unitInCodapTable": "BU"
+  },
   "COTTON, UPLAND - YIELD, MEASURED IN LB / ACRE": {
     "attributeNameInCodapTable": "Cotton Yield",
     "unitInCodapTable": "LB/Acre"
@@ -147,6 +151,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
   "COTTON, UPLAND - ACRES HARVESTED": {
     "attributeNameInCodapTable": "Cotton Area Harvested",
     "unitInCodapTable": "Acres Harvested"
+  },
+  "COTTON, UPLAND - PRODUCTION, MEASURED IN 480 LB BALES": {
+    "attributeNameInCodapTable": "Cotton Production",
+    "unitInCodapTable": "480 LB Bales"
   },
   "GRAPES - YIELD, MEASURED IN TONS / ACRE": {
     "attributeNameInCodapTable": "Grapes Yield",
@@ -156,6 +164,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "attributeNameInCodapTable": "Grapes Area Harvested",
     "unitInCodapTable": "Acres Harvested"
   },
+  "GRAPES - PRODUCTION, MEASURED IN TONS": {
+    "attributeNameInCodapTable": "Grapes Production",
+    "unitInCodapTable": "Tons"
+  },
   "HAY - YIELD, MEASURED IN TONS / ACRE": {
     "attributeNameInCodapTable": "Hay Yield",
     "unitInCodapTable": "Tons/Acre"
@@ -163,6 +175,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
   "HAY - ACRES HARVESTED": {
     "attributeNameInCodapTable": "Hay Area Harvested",
     "unitInCodapTable": "Acres Harvested"
+  },
+  "HAY - PRODUCTION, MEASURED IN TONS": {
+    "attributeNameInCodapTable": "Hay Production",
+    "unitInCodapTable": "Tons"
   },
   "OATS - YIELD, MEASURED IN BU / ACRE": {
     "attributeNameInCodapTable": "Oats Yield",
@@ -172,6 +188,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "attributeNameInCodapTable": "Oats Area Harvested",
     "unitInCodapTable": "Acres Harvested"
   },
+  "OATS - PRODUCTION, MEASURED IN BU": {
+    "attributeNameInCodapTable": "Oats Production",
+    "unitInCodapTable": "BU"
+  },
   "SOYBEANS - YIELD, MEASURED IN BU / ACRE": {
     "attributeNameInCodapTable": "Soybeans Yield",
     "unitInCodapTable": "BU/Acre"
@@ -179,6 +199,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
   "SOYBEANS - ACRES HARVESTED": {
     "attributeNameInCodapTable": "Soybeans Area Harvested",
     "unitInCodapTable": "Acres Harvested"
+  },
+  "SOYBEANS - PRODUCTION, MEASURED IN BU": {
+    "attributeNameInCodapTable": "Soybeans Production",
+    "unitInCodapTable": "BU"
   },
   "TOBACCO - YIELD, MEASURED IN LB / ACRE": {
     "attributeNameInCodapTable": "Tobacco Yield",
@@ -188,6 +212,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "attributeNameInCodapTable": "Tobacco Area Harvested",
     "unitInCodapTable": "Acres Harvested"
   },
+  "TOBACCO - PRODUCTION, MEASURED IN LB": {
+    "attributeNameInCodapTable": "Tobacco Production",
+    "unitInCodapTable": "LB"
+  },
   "WHEAT - YIELD, MEASURED IN BU / ACRE": {
     "attributeNameInCodapTable": "Wheat Yield",
     "unitInCodapTable": "BU/Acre"
@@ -195,6 +223,10 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
   "WHEAT - ACRES HARVESTED": {
     "attributeNameInCodapTable": "Wheat Area Harvested",
     "unitInCodapTable": "Acres Harvested"
+  },
+  "WHEAT - PRODUCTION, MEASURED IN BU": {
+    "attributeNameInCodapTable": "Wheat Production",
+    "unitInCodapTable": "BU"
   },
   "ECONOMIC CLASS: (1,000 TO 9,999 $)": {
     "attributeNameInCodapTable": "Small Farm ($1,000 - $9,999)",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -92,7 +92,7 @@ const economicOptions: IAttrOptions = {
 const cropUnitOptions: IAttrOptions = {
   key: "cropUnits",
   label: "Crop Production",
-  options: ["Area Harvested", "Yield"],
+  options: ["Area Harvested", "Production", "Yield"],
   instructions: "(Choose unit)"
 };
 export const cropOptions: IAttrOptions = {

--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -223,10 +223,12 @@ export const queryData: Array<IQueryHeaders> = [
       commodity_desc: "Corn",
       statisticcat_desc: {
         ["Area Harvested"]: "Area Harvested",
+        ["Production"]: "Production",
         ["Yield"]: "Yield"
       },
       short_desc: {
         ["Area Harvested"]: ["CORN, GRAIN - ACRES HARVESTED"],
+        ["Production"]: ["CORN, GRAIN - PRODUCTION, MEASURED IN BU"],
         ["Yield"]: ["CORN, GRAIN - YIELD, MEASURED IN BU / ACRE"]
       },
       years: {
@@ -241,10 +243,12 @@ export const queryData: Array<IQueryHeaders> = [
     commodity_desc: "Cotton",
     statisticcat_desc: {
       ["Area Harvested"]: "Area Harvested",
+      ["Production"]: "Production",
       ["Yield"]: "Yield"
     },
     short_desc: {
       ["Area Harvested"]: ["COTTON, UPLAND - ACRES HARVESTED"],
+      ["Production"]: ["COTTON, UPLAND - PRODUCTION, MEASURED IN 480 LB BALES"],
       ["Yield"]: ["COTTON, UPLAND - YIELD, MEASURED IN LB / ACRE"]
     },
     years: {
@@ -259,10 +263,12 @@ export const queryData: Array<IQueryHeaders> = [
     commodity_desc: "Grapes",
     statisticcat_desc: {
       ["Area Harvested"]: "Area Bearing",
+      ["Production"]: "Production",
       ["Yield"]: "Yield"
     },
     short_desc: {
       ["Area Harvested"]: ["GRAPES - ACRES BEARING"],
+      ["Production"]: ["GRAPES - PRODUCTION, MEASURED IN TONS"],
       ["Yield"]: ["GRAPES - YIELD, MEASURED IN TONS / ACRE"]
     },
     years: {
@@ -277,10 +283,12 @@ export const queryData: Array<IQueryHeaders> = [
     commodity_desc: "Hay",
     statisticcat_desc: {
       ["Area Harvested"]: "Area Harvested",
+      ["Production"]: "Production",
       ["Yield"]: "Yield"
     },
     short_desc: {
       ["Area Harvested"]: ["HAY - ACRES HARVESTED"],
+      ["Production"]: ["HAY - PRODUCTION, MEASURED IN TONS"],
       ["Yield"]: ["HAY - YIELD, MEASURED IN TONS / ACRE"]
     },
     years: {
@@ -295,10 +303,12 @@ export const queryData: Array<IQueryHeaders> = [
     commodity_desc: "Oats",
     statisticcat_desc: {
       ["Area Harvested"]: "Area Harvested",
+      ["Production"]: "Production",
       ["Yield"]: "Yield"
     },
     short_desc: {
       ["Area Harvested"]: ["OATS - ACRES HARVESTED"],
+      ["Production"]: ["OATS - PRODUCTION, MEASURED IN BU"],
       ["Yield"]: ["OATS - YIELD, MEASURED IN BU / ACRE"]
     },
     years: {
@@ -313,10 +323,12 @@ export const queryData: Array<IQueryHeaders> = [
     commodity_desc: "Soybeans",
     statisticcat_desc: {
       ["Area Harvested"]: "Area Harvested",
+      ["Production"]: "Production",
       ["Yield"]: "Yield"
     },
     short_desc: {
       ["Area Harvested"]: ["SOYBEANS - ACRES HARVESTED"],
+      ["Production"]: ["SOYBEANS - PRODUCTION, MEASURED IN BU"],
       ["Yield"]: ["SOYBEANS - YIELD, MEASURED IN BU / ACRE"]
     },
     years: {
@@ -331,10 +343,12 @@ export const queryData: Array<IQueryHeaders> = [
     commodity_desc: "Tobacco",
     statisticcat_desc: {
       ["Area Harvested"]: "Area Harvested",
+      ["Production"]: "Production",
       ["Yield"]: "Yield"
     },
     short_desc: {
       ["Area Harvested"]: ["TOBACCO - ACRES HARVESTED"],
+      ["Production"]: ["TOBACCO - PRODUCTION, MEASURED IN LB"],
       ["Yield"]: ["TOBACCO - YIELD, MEASURED IN LB / ACRE"]
     },
     years: {
@@ -349,10 +363,12 @@ export const queryData: Array<IQueryHeaders> = [
     commodity_desc: "Wheat",
     statisticcat_desc: {
       ["Area Harvested"]: "Area Harvested",
+      ["Production"]: "Production",
       ["Yield"]: "Yield"
     },
     short_desc: {
       ["Area Harvested"]: ["WHEAT - ACRES HARVESTED"],
+      ["Production"]: ["WHEAT - PRODUCTION, MEASURED IN BU"],
       ["Yield"]: ["WHEAT - YIELD, MEASURED IN BU / ACRE"]
     },
     years: {

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -65,11 +65,13 @@ export interface IResData {
 
 export interface ICropCategory {
   ["Area Harvested"]: string;
+  ["Production"]: string;
   ["Yield"]: string;
 }
 
 export interface ICropDataItem {
   ["Area Harvested"]: string[];
+  ["Production"]: string[];
   ["Yield"]: string[];
 }
 
@@ -165,7 +167,7 @@ export const isLivestockDataItem = (desc: unknown): desc is ILivestockDataItem =
 };
 
 export const isCropDataItemKey = (key: string): key is keyof ICropDataItem => {
-  return key === "Area Harvested" || key === "Yield";
+  return key === "Area Harvested" || key === "Production" || key === "Yield";
 };
 
 export const isLivestockDataItemKey = (key: string): key is keyof ILivestockDataItem => {


### PR DESCRIPTION
[NP-10](https://concord-consortium.atlassian.net/browse/NP-10)

Adds "Production" as a new crop unit option alongside the existing "Area Harvested" and "Yield" options. Also adjusts plugin width in UI slightly to accommodate new unit option without wrapping to new line.

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-production-unit-option-2](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-production-unit-option-2/)

[NP-10]: https://concord-consortium.atlassian.net/browse/NP-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ