### PR TITLE
chore: move Agricultural District to County collection (NP-9)

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -253,7 +253,8 @@ const createStateCollection = async () => {
 const createCountyCollection = async () => {
   const attrs: Array<Attribute> = [
     makeCODAPAttributeDef({"name": "County"}, "County"),
-    makeCODAPAttributeDef({"name": "County Boundary"}, "County")
+    makeCODAPAttributeDef({"name": "County Boundary"}, "County"),
+    makeCODAPAttributeDef({"name": "Agricultural District"}, "County"),
   ];
   await createChildCollection(dataSetName, "Counties", "States", attrs);
 };
@@ -263,7 +264,8 @@ const createDataCollection = async (geoLevel: GeographicLevel, allAttrs: Array<A
     attr.name !== "State" && 
     attr.name !== "State Boundary" && 
     attr.name !== "County" && 
-    attr.name !== "County Boundary"
+    attr.name !== "County Boundary" && 
+    attr.name !== "Agricultural District"
   );
   const dataAttrDefs = dataAttrs.map((attr) => makeCODAPAttributeDef(attr, geoLevel));
   await createChildCollection(dataSetName, "Data", parentCollection, dataAttrDefs);


### PR DESCRIPTION
[NP-9](https://concord-consortium.atlassian.net/browse/NP-9)

Moves the Agricultural District column to the County collection in the generated CODAP table. So when Place > Size is set to County, and the generated CODAP table contains a Count collection, the Agricultural District column appears to the right of the County Boundary column.

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-agricultural-district-to-codap-table-2/](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-agricultural-district-to-codap-table-2/)

[NP-9]: https://concord-consortium.atlassian.net/browse/NP-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ