### PR TITLE
chore: change "Acres Operated" label to "Size" (NP-13)

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -99,7 +99,7 @@ context("Test the overall app", () => {
         // Farmer Demographics
         "Total Farmers", "Age", "Race", "Gender",
         // Farm Demographics  
-        "Total Farms", "Organization Type", "Economic Class", "Acres Operated", "Organic",
+        "Total Farms", "Organization Type", "Economic Class", "Size", "Organic",
         // Economics & Wages
         "Labor Status", "Wages", "Time Worked",
         // Crop Production - unit

--- a/src/components/options.tsx
+++ b/src/components/options.tsx
@@ -59,7 +59,7 @@ export const Options: React.FC<IOptions> = (props) => {
               newSelection[optionKey] = newArray.filter((o) => o !== e.target.value);
             }
           } else if (optionKey === "farmDemographics" && e.target.value === "Total Farms") {
-            const shouldFilter = !includesAny(["Economic Class", "Acres Operated", "Organic", "Organization Type"], "farmDemographics");
+            const shouldFilter = !includesAny(["Economic Class", "Size", "Organic", "Organization Type"], "farmDemographics");
             if (shouldFilter) {
               newSelection[optionKey] = newArray.filter((o) => o !== e.target.value);
             }

--- a/src/constants/codapMetadata.ts
+++ b/src/constants/codapMetadata.ts
@@ -311,7 +311,7 @@ export const economicClassAttirbutes = [
   "ECONOMIC CLASS: (1,000,000 OR MORE $)"
 ];
 
-export const acresOperatedAttributes = [
+export const sizeAttributes = [
   "AREA OPERATED: (1.0 TO 9.9 ACRES)",
   "AREA OPERATED: (10.0 TO 49.9 ACRES)",
   "AREA OPERATED: (50.0 TO 100 ACRES)",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -80,7 +80,7 @@ const farmerOptions: IAttrOptions = {
 const farmOptions: IAttrOptions = {
   key: "farmDemographics",
   label: "Farm Demographics",
-  options: ["Total Farms", "Organization Type", "Economic Class", "Acres Operated", "Organic"],
+  options: ["Total Farms", "Organization Type", "Economic Class", "Size", "Organic"],
   instructions: null
 };
 const economicOptions: IAttrOptions = {

--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -153,7 +153,7 @@ export const queryData: Array<IQueryHeaders> = [
       }
   },
   {
-      plugInAttribute: "Acres Operated",
+      plugInAttribute: "Size",
       sect_desc: "Economics",
       group_desc: "Farms & Land & Assets",
       commodity_desc: "Farm Operations",

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -394,7 +394,7 @@ const processAttributeData = async (props: IProcessAttributeData) => {
             const codapColumnName = attrToCODAPColumnName[matchingData[0].short_desc].attributeNameInCodapTable;
             item[codapColumnName] = Value;
         } else if (attribute === "Size") {
-          // special case for handling acres operated, where we have to sum up the values of several data items
+          // special case for handling size (acres operated), where we have to sum up the values of several data items
           const acreTotals: IAcreTotals = {
             [strings.oneTo9Acres]: {
               [strings.oneTo9Acres]: 0

--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -14,7 +14,7 @@ import { multiRegions } from "../constants/regionData";
 import { cropOptions, livestockOptions, fiftyStates } from "../constants/constants";
 import { countyData } from "../constants/counties";
 import { getQueryParams } from "./utils";
-import { acresOperatedAttributes, attrToCODAPColumnName, economicClassAttirbutes } from "../constants/codapMetadata";
+import { sizeAttributes, attrToCODAPColumnName, economicClassAttirbutes } from "../constants/codapMetadata";
 import { strings } from "../constants/strings";
 
 const baseURL = process.env.REACT_APP_NASS_PROXY_URL;
@@ -154,10 +154,10 @@ export const getAllAttrs = (selectedOptions: IStateOptions) => {
           const codapColumnUnit = attrToCODAPColumnName[econAttr].unitInCodapTable;
           allAttrs.push({"name": codapColumnName, "unit": codapColumnUnit});
         }
-      } else if (attribute === "Acres Operated") {
-        for (const acresAttr of acresOperatedAttributes) {
-          const codapColumnName = attrToCODAPColumnName[acresAttr].attributeNameInCodapTable;
-          const codapColumnUnit = attrToCODAPColumnName[acresAttr].unitInCodapTable;
+      } else if (attribute === "Size") {
+        for (const sizeAttr of sizeAttributes) {
+          const codapColumnName = attrToCODAPColumnName[sizeAttr].attributeNameInCodapTable;
+          const codapColumnUnit = attrToCODAPColumnName[sizeAttr].unitInCodapTable;
           allAttrs.push({"name": codapColumnName, "unit": codapColumnUnit});
         }
       } else if (Array.isArray(short_desc)) {
@@ -393,7 +393,7 @@ const processAttributeData = async (props: IProcessAttributeData) => {
             const { Value } = matchingData[0];
             const codapColumnName = attrToCODAPColumnName[matchingData[0].short_desc].attributeNameInCodapTable;
             item[codapColumnName] = Value;
-        } else if (attribute === "Acres Operated") {
+        } else if (attribute === "Size") {
           // special case for handling acres operated, where we have to sum up the values of several data items
           const acreTotals: IAcreTotals = {
             [strings.oneTo9Acres]: {


### PR DESCRIPTION
[NP-13](https://concord-consortium.atlassian.net/browse/NP-13)

Changes the check box label “Acres Operated” to “Size”. The data still pulls from the same place and the generated CODAP table column headers remain the same.

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/change-acres-operated-to-size/](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/change-acres-operated-to-size/)

[NP-13]: https://concord-consortium.atlassian.net/browse/NP-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ