### PR TITLE
feat: Add Total Area attribute (NP-17)

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -99,7 +99,7 @@ context("Test the overall app", () => {
         // Farmer Demographics
         "Total Farmers", "Age", "Race", "Gender",
         // Farm Demographics  
-        "Total Farms", "Organization Type", "Economic Class", "Size", "Organic",
+        "Total Farms", "Total Area", "Organization Type", "Economic Class", "Size", "Organic",
         // Economics & Wages
         "Labor Status", "Wages", "Time Worked",
         // Crop Production - unit

--- a/src/constants/codapMetadata.ts
+++ b/src/constants/codapMetadata.ts
@@ -105,8 +105,8 @@ export const attrToCODAPColumnName: IAttrToCodapColumn = {
     "unitInCodapTable": "# of Farms"
   },
   "FARM OPERATIONS - ACRES OPERATED": {
-    "attributeNameInCodapTable": "",
-    "unitInCodapTable": "# of Farms"
+    "attributeNameInCodapTable": "Total Area",
+    "unitInCodapTable": "Acres"
   },
   "FARM OPERATIONS, ORGANIC - NUMBER OF OPERATIONS": {
     "attributeNameInCodapTable": "Organic",

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -80,7 +80,7 @@ const farmerOptions: IAttrOptions = {
 const farmOptions: IAttrOptions = {
   key: "farmDemographics",
   label: "Farm Demographics",
-  options: ["Total Farms", "Organization Type", "Economic Class", "Size", "Organic"],
+  options: ["Total Farms", "Total Area", "Organization Type", "Economic Class", "Size", "Organic"],
   instructions: null
 };
 const economicOptions: IAttrOptions = {

--- a/src/constants/queryHeaders.ts
+++ b/src/constants/queryHeaders.ts
@@ -122,6 +122,18 @@ export const queryData: Array<IQueryHeaders> = [
       }
   },
   {
+    plugInAttribute: "Total Area",
+    ...sharedEconomicHeaders,
+    statisticcat_desc: "Area Operated",
+    short_desc: ["FARM OPERATIONS - ACRES OPERATED"],
+    domain_desc: "Total",
+    geographicAreas: ["State", "County"],
+    years: {
+      "County": censusYears,
+      "State": yearsFrom(1950)
+    }
+  },
+  {
       plugInAttribute: "Organization Type",
       sect_desc: "Demographics",
       group_desc: "Farms & Land & Assets",


### PR DESCRIPTION
[NP-17](https://concord-consortium.atlassian.net/browse/NP-17)

Adds a Total Area option under Attributes > Farm Demographics, directly after Total Farms. In the generated CODAP table, the data is displayed in a column titled "Total Area" with a unit of "Acres".

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-total-area-attribute/](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/add-total-area-attribute/)

[NP-17]: https://concord-consortium.atlassian.net/browse/NP-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ