### PR TITLE
chore: streamline versioning (NP-18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nass-plugin",
-  "version": "0.1.0",
+  "private": true,
   "description": "Concord Consortium NASS Plugin",
   "main": "index.js",
   "browserslist": "> 0.2%, last 5 versions, Firefox ESR, not dead, not ie > 0",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -18,7 +18,7 @@ import Error from "../assets/warning.svg";
 import css from "./app.scss";
 
 const iFrameDescriptor ={
-  version: "0.0.1",
+  version: process.env.PLUGIN_VERSION || "local-build",
   pluginName: "nass-plugin",
   title: "NASS Quickstats Data",
   dimensions: {width: 327, height: 400},

--- a/src/components/global.d.ts
+++ b/src/components/global.d.ts
@@ -3,6 +3,7 @@ declare module "*.svg";
 
 declare const process: {
   env: {
+    PLUGIN_VERSION?: string;
     REACT_APP_NASS_PROXY_URL?: string;
   };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,9 +148,6 @@ module.exports = (env, argv) => {
       warningsFilter: /export .* was not found in/,
     },
     plugins: [
-      new webpack.DefinePlugin({
-        'process.env.REACT_APP_NASS_PROXY_URL': JSON.stringify(process.env.REACT_APP_NASS_PROXY_URL || ''),
-      }),
       new ESLintPlugin({
         extensions: ['ts', 'tsx', 'js', 'jsx'],
       }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,12 @@ const os = require('os');
 // `branch/[branch-name]/` or `version/[tag-name]/`
 // See the following documentation for more detail:
 //   https://github.com/concord-consortium/s3-deploy-action/blob/main/README.md#top-branch-example
-const DEPLOY_PATH = process.env.DEPLOY_PATH;
+// We default it to null, so the EnvironmentPlugin below will not complain if it isn't available in
+// the environment.
+const DEPLOY_PATH = process.env.DEPLOY_PATH ?? null;
+
+// Derive PLUGIN_VERSION from DEPLOY_PATH to show it in the UI
+const PLUGIN_VERSION = DEPLOY_PATH ? DEPLOY_PATH.replace(/\/$/, '').split('/').pop() : 'local-build';
 
 module.exports = (env, argv) => {
   const devMode = argv.mode !== 'production';
@@ -165,6 +170,13 @@ module.exports = (env, argv) => {
         publicPath: DEPLOY_PATH
       })] : []),
       new CleanWebpackPlugin(),
+      // Provide these environment variables to the built code
+      // See https://webpack.js.org/plugins/environment-plugin/ for documentation
+      new webpack.EnvironmentPlugin({
+        DEPLOY_PATH,                           // not necessary but can't hurt
+        PLUGIN_VERSION,                        // derived from DEPLOY_PATH
+        REACT_APP_NASS_PROXY_URL: undefined,   // required proxy url
+      }),
     ]
   };
 };


### PR DESCRIPTION
[NP-18](https://concord-consortium.atlassian.net/browse/NP-18)

These changes replicate the changes in [this DAVAI plugin PR](https://github.com/concord-consortium/davai-plugin/pull/79) so when the NASS plugin is built the build system gets the version string from `DEPLOY_PATH` which will either be a branch or tag.

(I accidentally requested a Copilot review but hid/deleted that. Its only comment was something it said on the other PR which @scytacki dismissed.)

[NP-18]: https://concord-consortium.atlassian.net/browse/NP-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ