### PR TITLE
chore: change displayed title of plugin (NP-20)

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -19,9 +19,9 @@ import css from "./app.scss";
 
 const iFrameDescriptor ={
   version: process.env.PLUGIN_VERSION || "local-build",
-  pluginName: "nass-plugin",
+  pluginName: "National Agricultural Statistics Service",
   title: "NASS Quickstats Data",
-  dimensions: {width: 327, height: 400},
+  dimensions: {width: 335, height: 400},
 };
 
 function App() {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -21,7 +21,7 @@ const iFrameDescriptor ={
   version: process.env.PLUGIN_VERSION || "local-build",
   pluginName: "National Agricultural Statistics Service",
   title: "NASS Quickstats Data",
-  dimensions: {width: 335, height: 400},
+  dimensions: {width: 355, height: 400},
 };
 
 function App() {


### PR DESCRIPTION
[NP-20](https://concord-consortium.atlassian.net/browse/NP-20)

Changes the plugin's displayed title from "nass-plugin" to "National Agricultural Statistics Service".

It's possible for a long version string (e.g., the branch name `change-displayed-title-of-plugin`) to overlap the new, longer plugin title in the UI. That won't be an issue with the actual version numbers that will be shown in production. It's also more of a CODAP v3 layout issue that should be addressed separately.

URL for Testing:
[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/change-displayed-title-of-plugin/](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/change-displayed-title-of-plugin/?v2)

[NP-20]: https://concord-consortium.atlassian.net/browse/NP-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ