### PR TITLE
fix: Make Agricultural District a categorical attribute (NP-21)

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -13,7 +13,7 @@ import { Attribute, GeographicLevel, ICropDataItem, ILivestockCategory, ILivesto
 import { multiRegions } from "../constants/regionData";
 import { cropOptions, livestockOptions, fiftyStates } from "../constants/constants";
 import { countyData } from "../constants/counties";
-import { getQueryParams } from "./utils";
+import { getQueryParams, isCategorical } from "./utils";
 import { sizeAttributes, attrToCODAPColumnName, economicClassAttirbutes } from "../constants/codapMetadata";
 import { strings } from "../constants/strings";
 
@@ -241,7 +241,7 @@ const makeCODAPAttributeDef = (attr: Attribute, geoLevel: GeographicLevel) => {
     return {
       name,
       unit,
-      type: name === "State" || name === "County" ? "categorical" : "numeric"
+      type: isCategorical(name) ? "categorical" : "numeric"
     };
   }
 };

--- a/src/scripts/utils.test.ts
+++ b/src/scripts/utils.test.ts
@@ -1,4 +1,4 @@
-import { flatten, getQueryParams, isDefaultSelection } from "./utils";
+import { flatten, getQueryParams, isDefaultSelection, isCategorical } from "./utils";
 import { IStateOptions } from "../constants/types";
 
 describe("utils", () => {
@@ -211,6 +211,33 @@ describe("utils", () => {
       };
 
       expect(isDefaultSelection(selectedWithMixedOrder, defaultsWithMixed)).toBe(true);
+    });
+  });
+
+  describe("isCategorical", () => {
+    it("should return true for State, County, or Agricultural District", () => {
+      expect(isCategorical("State")).toBe(true);
+      expect(isCategorical("County")).toBe(true);
+      expect(isCategorical("Agricultural District")).toBe(true);
+    });
+
+    it("should return false for Year", () => {
+      expect(isCategorical("Year")).toBe(false);
+    });
+
+    it("should return false for numeric attribute names", () => {
+      expect(isCategorical("Total Number of Farmers")).toBe(false);
+      expect(isCategorical("Total Area")).toBe(false);
+      expect(isCategorical("Corn Yield")).toBe(false);
+    });
+
+    it("should return false for boundary attributes", () => {
+      expect(isCategorical("State Boundary")).toBe(false);
+      expect(isCategorical("County Boundary")).toBe(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(isCategorical("")).toBe(false);
     });
   });
 });

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -29,3 +29,7 @@ export const isDefaultSelection = (selectedOptions: IStateOptions, defaultOption
     return selected === defaultVal;
   });
 };
+
+export const isCategorical = (name: string): boolean => {
+  return name === "State" || name === "County" || name === "Agricultural District";
+};


### PR DESCRIPTION
[NP-21](https://concord-consortium.atlassian.net/browse/NP-21)

Ensures Agricultural District is treated as a categorical attribute in CODAP. Moves logic for checking attribute type based on name to a new utility function `isCategorical`.

[NP-21]: https://concord-consortium.atlassian.net/browse/NP-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ