### PR TITLE
fix: incorrect hierarchy for counties when missing data (NP-22)

### DIFF
--- a/src/scripts/api.ts
+++ b/src/scripts/api.ts
@@ -379,6 +379,36 @@ interface IProcessAttributeData {
   stateArray: string[]
 }
 
+/**
+ * Backfills Agricultural District values across all items for the same county/state.
+ * This prevents CODAP from creating duplicate county parent cases when some years have
+ * Agricultural District data and others don't.
+ */
+const backfillAgriculturalDistricts = (items: any[]) => {
+  // Build a map of county -> state -> agricultural district
+  const countyDistrictMap: {[key: string]: {[key: string]: string}} = {};
+  
+  items.forEach((item: any) => {
+    if (item["Agricultural District"]) {
+      const county = item.County;
+      const state = item.State;
+      if (!countyDistrictMap[county]) {
+        countyDistrictMap[county] = {};
+      }
+      countyDistrictMap[county][state] = item["Agricultural District"];
+    }
+  });
+  
+  // Backfill all items for those counties with their Agricultural District value
+  items.forEach((item: any) => {
+    const county = item.County;
+    const state = item.State;
+    if (countyDistrictMap[county]?.[state]) {
+      item["Agricultural District"] = countyDistrictMap[county][state];
+    }
+  });
+};
+
 const processAttributeData = async (props: IProcessAttributeData) => {
   const {attribute, items, geographicLevel, years, unit, selectedOptions, setReqCount, stateArray} = props;
   const queryParams = getQueryParams(attribute);
@@ -391,6 +421,7 @@ const processAttributeData = async (props: IProcessAttributeData) => {
       // find all the data items that match this item's location and year
       const matchingData = findMatchingData({isMultiStateRegion, data, item, geoLevel: geographicLevel});
       if (matchingData.length) {
+        // Populate Agricultural District if available (backfill logic will propagate to all items for this county)
         if (geographicLevel === "County" && matchingData[0].asd_desc && !item["Agricultural District"]) {
           item["Agricultural District"] = matchingData[0].asd_desc;
         }
@@ -504,6 +535,10 @@ const getItems = async (selectedOptions: IStateOptions, setReqCount: ISetReqCoun
         await processAttributeData({attribute, items, geographicLevel, years, unit: "", selectedOptions, setReqCount, stateArray});
       }
     }
+  }
+
+  if (geographicLevel === "County") {
+    backfillAgriculturalDistricts(items);
   }
 
   return items;


### PR DESCRIPTION
[NP-22](https://concord-consortium.atlassian.net/browse/NP-22)

Fixes an issue where if a year is selected for which there isn’t data, each county gets two separate rows in the CODAP table County collection, once with an empty Agricultural District value, and once with a valid Agricultural District value. The changes backfill the data that doesn't contain Agricultural District values with the correct values, which ensures a single row per County in the CODAP table.

**URL for Testing**

[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/fix-incorrect-hierarchy-for-counties-when-missing-data/](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/fix-incorrect-hierarchy-for-counties-when-missing-data/)

**Example Settings to Reveal the Functionality**
- Set _Size of area_ for data to _County_
- Choose _California_ from the list of states
- Under _Farm Demogrphics_, choose _Total Farms_ and _Total Area_
- Under _Crop Production_, choose _Soybeans_
- Under _Years_, choose _2024_, _2023_, _2017_, _2012_

**URL Illustrating Broken Behavior**

[https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/main/#shared=https%3A%2F%2Fcfm-shared.concord.org%2FqGlkjUAofbccqYwTjsms%2Ffile.json](https://codap3.concord.org/branch/main/index.html?di=https://nass-plugin.concord.org/branch/main/#shared=https%3A%2F%2Fcfm-shared.concord.org%2FqGlkjUAofbccqYwTjsms%2Ffile.json)

[NP-22]: https://concord-consortium.atlassian.net/browse/NP-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ